### PR TITLE
Support multiple certificates for ssh-inscribe server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 .DS_Store
 build
+.vscode

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,10 +1,18 @@
 package server
 
 import (
+	"crypto/tls"
 	"path"
 
 	"github.com/aakso/ssh-inscribe/pkg/globals"
+
+	"github.com/pkg/errors"
 )
+
+type CertificateConfig struct {
+	Certificates   []tls.Certificate
+	CertificateMap map[string]*tls.Certificate
+}
 
 type AuthBackend struct {
 	Type    string
@@ -16,6 +24,9 @@ type Config struct {
 	Listen                    string
 	TLSCertFile               string        `yaml:"TLSCertFile"`
 	TLSKeyFile                string        `yaml:"TLSKeyFile"`
+	TLSCertFiles              []string      `yaml:"TLSCertFiles"`
+	TLSKeyFiles               []string      `yaml:"TLSKeyFiles"`
+	TLSCertNames              []string      `yaml:"TLSCertNames"`
 	AuthBackends              []AuthBackend `yaml:"authBackends"`
 	DefaultAuthBackends       []string      `yaml:"defaultAuthBackends"`
 	MaxCertLifetime           string        `yaml:"maxCertLifetime"`
@@ -28,9 +39,11 @@ type Config struct {
 }
 
 var Defaults *Config = &Config{
-	Listen:      ":8540",
-	TLSCertFile: "",
-	TLSKeyFile:  "",
+	Listen:       ":8540",
+	TLSCertFile:  "",
+	TLSKeyFile:   "",
+	TLSCertFiles: []string{},
+	TLSKeyFiles:  []string{},
 	AuthBackends: []AuthBackend{
 		AuthBackend{
 			Type:    "authfile",
@@ -46,4 +59,43 @@ var Defaults *Config = &Config{
 	PKCS11Pin:                 "",
 	CertSigningKeyFingerprint: "",
 	TokenSigningKey:           "",
+}
+
+func (c Config) GetCertificateMap() (cc CertificateConfig, err error) {
+	cc = CertificateConfig{
+		Certificates:   []tls.Certificate{},
+		CertificateMap: make(map[string]*tls.Certificate),
+	}
+
+	// Single certificate has no name configuration
+	if c.TLSCertFile != "" && c.TLSKeyFile != "" {
+		if len(c.TLSCertFiles) > 0 {
+			return cc, errors.New("Unsupported configuration, either set TLSCertFile or TLSCertFiles, not both")
+		}
+
+		var certificate, err = tls.LoadX509KeyPair(c.TLSCertFile, c.TLSKeyFile)
+		if err != nil {
+			return cc, err
+		}
+		cc.Certificates = append(cc.Certificates, certificate)
+		return cc, nil
+	}
+
+	if len(c.TLSCertFiles) > 0 && len(c.TLSKeyFiles) > 0 && len(c.TLSCertNames) > 0 {
+		if (len(c.TLSCertFiles) != len(c.TLSKeyFiles)) || (len(c.TLSCertFiles) != len(c.TLSCertNames)) {
+			return cc, errors.New("TLSCertFiles, TLSKeyFiles and TLSCertNames must contain same number of elements")
+		}
+
+		cc.Certificates = make([]tls.Certificate, len(c.TLSCertFiles))
+		for index, cert := range c.TLSCertFiles {
+			var certificate, err = tls.LoadX509KeyPair(cert, c.TLSKeyFiles[index])
+			if err != nil {
+				return cc, err
+			}
+			cc.Certificates[index] = certificate
+			cc.CertificateMap[c.TLSCertNames[index]] = &cc.Certificates[index]
+		}
+		return cc, nil
+	}
+	return cc, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,11 +63,9 @@ func (s *Server) Start() error {
 		if err != nil {
 			return errors.Wrap(err, "cannot start server")
 		}
-		log.WithField("listen", fmt.Sprintf("https://%s", s.config.Listen)).Info("server terminated")
 	} else {
 		log.WithField("listen", fmt.Sprintf("http://%s", s.config.Listen)).Warn("server starting without TLS")
 		err = s.web.Start(s.config.Listen)
-		log.WithField("listen", fmt.Sprintf("http://%s", s.config.Listen)).Info("server terminated")
 	}
 	if err != nil {
 		return errors.Wrap(err, "cannot start server")


### PR DESCRIPTION
Added support for multiple certificates to ssh-inscribe server.

Adds configuration options TLSCertificateFiles (list), TLSCertificateKeys (list), TLSCertificateNames (list) that can be used to configure multiple certificates for the server instead of the single TLSCertificateFile, TLSCertificateKey configuration options.

