### PR TITLE
fix(env vars): change boolean env vars to actual booleans

### DIFF
--- a/cliclient/cmd/request.go
+++ b/cliclient/cmd/request.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/aakso/ssh-inscribe/pkg/client"
 	"github.com/spf13/cobra"
@@ -49,7 +50,7 @@ func init() {
 		return nil, cobra.ShellCompDirectiveDefault
 	})
 
-	if os.Getenv("SSH_INSCRIBE_WRITE") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_WRITE")); err == nil && val {
 		ClientConfig.WriteCert = true
 	}
 	ReqCmd.Flags().BoolVarP(
@@ -60,7 +61,7 @@ func init() {
 		"Write certificate (and generated keys) to file specified by <identity> ($SSH_INSCRIBE_WRITE)",
 	)
 
-	if os.Getenv("SSH_INSCRIBE_RENEW") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_RENEW")); err == nil && val {
 		ClientConfig.AlwaysRenew = true
 	}
 	ReqCmd.Flags().BoolVar(
@@ -70,7 +71,7 @@ func init() {
 		"Always renew the certificate even if it is not expired ($SSH_INSCRIBE_RENEW)",
 	)
 
-	if os.Getenv("SSH_INSCRIBE_USE_AGENT") == "0" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_USE_AGENT")); err == nil && !val {
 		ClientConfig.UseAgent = false
 	}
 	ReqCmd.Flags().BoolVar(
@@ -80,7 +81,7 @@ func init() {
 		"Store key and certificate to a ssh-agent specified by $SSH_AUTH_SOCK ($SSH_INSCRIBE_USE_AGENT)",
 	)
 
-	if os.Getenv("SSH_INSCRIBE_GENKEY") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_GENKEY")); err == nil && val {
 		ClientConfig.GenerateKeypair = true
 	}
 	ReqCmd.Flags().BoolVarP(

--- a/cliclient/cmd/root.go
+++ b/cliclient/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 	)
 	_ = RootCmd.RegisterFlagCompletionFunc("retries", noCompletion)
 
-	if os.Getenv("SSH_INSCRIBE_DEBUG") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_DEBUG")); err == nil && val {
 		ClientConfig.Debug = true
 	}
 	RootCmd.PersistentFlags().BoolVar(
@@ -106,7 +106,7 @@ func init() {
 		"Enable request level debugging (outputs sensitive data) ($SSH_INSCRIBE_DEBUG)",
 	)
 
-	if os.Getenv("SSH_INSCRIBE_INSECURE") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_INSECURE")); err == nil && val {
 		ClientConfig.Insecure = true
 	}
 	RootCmd.PersistentFlags().BoolVar(
@@ -129,7 +129,7 @@ func init() {
 		return logging.GetAvailableLevelNames(), cobra.ShellCompDirectiveNoFileComp
 	})
 
-	if os.Getenv("SSH_INSCRIBE_QUIET") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_QUIET")); err == nil && val {
 		ClientConfig.Quiet = true
 	}
 	RootCmd.PersistentFlags().BoolVarP(
@@ -140,7 +140,7 @@ func init() {
 		"Set quiet mode ($SSH_INSCRIBE_QUIET)",
 	)
 
-	if os.Getenv("SSH_INSCRIBE_AGENT_CONFIRM") != "" {
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_AGENT_CONFIRM")); err == nil && val {
 		ClientConfig.Quiet = true
 	}
 	RootCmd.PersistentFlags().BoolVar(


### PR DESCRIPTION
This fixes SSH_INSCRIBE_USE_AGENT env var to act as boolean instead of only value 0 disabling it.

In addition fixes all other boolean env vars (SSH_INSCRIBE_WRITE, SSH_INSCRIBE_RENEW, SSH_INSCRIBE_GENKEY, SSH_INSCRIBE_DEBUG, SSH_INSCRIBE_INSECURE, SSH_INSCRIBE_QUIET) to act as actual booleans instead of non-empty value setting the config option to true.