### PR TITLE
feat: add support for selecting a signing algo for RSA CA keys

### DIFF
--- a/cliclient/cmd/root.go
+++ b/cliclient/cmd/root.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/aakso/ssh-inscribe/pkg/client"
 	"github.com/aakso/ssh-inscribe/pkg/logging"
-	"github.com/spf13/cobra"
 )
 
 var RootCmd = &cobra.Command{
@@ -246,5 +247,20 @@ func init() {
 			sizes = []string{"2048", "3072", "4096", "8192"}
 		}
 		return sizes, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	if opt := os.Getenv("SSH_INSCRIBE_SIGNING_OPTION"); opt != "" {
+		ClientConfig.SigningOption = opt
+	}
+	RootCmd.PersistentFlags().StringVarP(
+		&ClientConfig.SigningOption,
+		"signing-option",
+		"o",
+		ClientConfig.SigningOption,
+		"Optional flag to be used in signing. This is only used if the CA's key is RSA. ($SSH_INSCRIBE_SIGNING_OPTION)\n"+
+			"If not, this option is silently ignored. Valid values: rsa-sha2-256 and rsa-sha2-512",
+	)
+	_ = RootCmd.RegisterFlagCompletionFunc("signing-option", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"rsa-sha2-256", "rsa-sha2-512"}, cobra.ShellCompDirectiveNoFileComp
 	})
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -560,6 +560,9 @@ func (c *Client) sign() error {
 	if c.Config.ExcludePrincipals != "" {
 		req.SetQueryParam("exclude_principals", c.Config.ExcludePrincipals)
 	}
+	if c.Config.SigningOption != "" {
+		req.SetQueryParam("signing_option", c.Config.SigningOption)
+	}
 
 	res, err := req.Post(c.urlFor("sign"))
 	if err != nil {
@@ -1028,6 +1031,8 @@ func (c *Client) printCertificate() {
 	fmt.Printf("\n%20s: %s (%s)", "CA Fingerprint",
 		ssh.FingerprintSHA256(c.ca),
 		ssh.FingerprintLegacyMD5(c.ca))
+	fmt.Printf("\n%20s: %s", "CA Signature Format",
+		c.userCert.Signature.Format)
 	fmt.Printf("\n%20s: %s", "KeyId", c.userCert.KeyId)
 	fmt.Printf("\n%20s: %s", "Valid from", validFrom)
 	fmt.Printf("\n%20s: %s", "Valid to", validTo)

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -3,61 +3,67 @@ package client
 import "time"
 
 type Config struct {
-	URL   string
+	// URL selects an ssh-inscribe server to talk to
+	URL string
+
+	// Debug enables request debugging
 	Debug bool
 
-	// Always renew even if current certificate is valid
+	// AlwaysRenew requests to renew even if current certificate is valid
 	AlwaysRenew bool
 
-	// Path to private key file to use, if empty, generate a new key
+	// IdentityFile selects private key to use to request certificate for
 	IdentityFile string
 
-	// Path to CA private key file. Only used when adding initial signing key to the server
+	// CAKeyFile selects a CA private key file. Only used when adding initial signing key to the server
 	CAKeyFile string
 
-	// Whether to request challenge for an encrypted CA private key
+	// CAChallenge selects whether to request challenge for an encrypted CA private key
 	CAChallenge bool
 
-	// Generate ad-hoc keypair
+	// GenerateKeypair requests to generate ad-hoc keypair
 	GenerateKeypair bool
 
-	// Generated key type, valid: rsa, ed25519
+	// GenerateKeypairType selects the generated key type, valid: rsa, ed25519
 	GenerateKeypairType string
 
-	// Generated key size, only valid for rsa
+	// GenerateKeypairSize selects the generated key size, only valid for rsa
 	GenerateKeypairSize int
 
-	// Write certificate to <IdentityFile>-cert.pub
+	// WriteCert writes certificate to <IdentityFile>-cert.pub
 	WriteCert bool
 
-	// Store key and certificate to a ssh-agent
+	// UseAgent requests to store key and certificate to a ssh-agent
 	UseAgent bool
 
-	// Store certs and keys with confirm constraint
+	// AgentConfirm requests certs and keys to be stored with confirm constraint
 	AgentConfirm bool
 
-	// Do not print anything
+	// Quiet disables printing to stdout
 	Quiet bool
 
-	// Request specific certificate lifetime
+	// CertLifetime requests a specific certificate lifetime
 	CertLifetime time.Duration
 
-	// Skip TLS validation for server connection
+	// Insecure skips TLS validation for server connection
 	Insecure bool
 
-	// Client timeout
+	// Timeout specifies the client timeout
 	Timeout time.Duration
 
-	// How many retries on failed requests
-	// For example if the server timeouts
+	// Retries specifies how many retries to do on failed requests. For example if the server timeouts
 	Retries int
 
-	// Which auth endpoints to login to
+	// LoginAuthEndpoints selects which auth endpoints to login to
 	LoginAuthEndpoints []string
 
-	// Request only principals matching the pattern to be included
+	// IncludePrincipals requests only principals matching the pattern to be included
 	IncludePrincipals string
 
-	// Request only principals not matching the pattern to be included
+	// ExcludePrincipals requests only principals not matching the pattern to be included
 	ExcludePrincipals string
+
+	// SigningOption sets an optional flag to be used in signing. This is only used if the CA's key is RSA.
+	// If not, this option is silently ignored. Valid values: rsa-sha2-256 and rsa-sha2-512
+	SigningOption string
 }

--- a/pkg/keysigner/keysigner_test.go
+++ b/pkg/keysigner/keysigner_test.go
@@ -2,6 +2,7 @@ package keysigner
 
 import (
 	"bytes"
+	"crypto"
 	"fmt"
 	"os"
 	"path"
@@ -277,13 +278,28 @@ func TestSign(t *testing.T) {
 	defer srv.KillAgent()
 	defer srv.Close()
 
+	type algoPair struct {
+		opt          crypto.SignerOpts
+		expectFormat string
+	}
+	testAlgos := []algoPair{
+		{opt: nil, expectFormat: "ssh-rsa"},
+		{opt: crypto.SHA256, expectFormat: "rsa-sha2-256"},
+		{opt: crypto.SHA512, expectFormat: "rsa-sha2-512"},
+	}
+
 	assert.True(t, wait(srv.AgentPing))
 	if assert.NoError(t, srv.AddSigningKey(testCaPrivatePem, nil, "test-ca")) {
 		if assert.True(t, srv.Ready(), "service should be ready") {
-			userCert := testCert()
-			assert.NoError(t, srv.SignCertificate(userCert), "signing should work")
-			assert.NoError(t, checkCert(userCert))
-			fmt.Println("certificate:", string(ssh.MarshalAuthorizedKey(userCert)))
+			for _, params := range testAlgos {
+				t.Run(params.expectFormat, func(t *testing.T) {
+					userCert := testCert()
+					assert.NoError(t, srv.SignCertificate(userCert, params.opt), "signing should work")
+					assert.NoError(t, checkCert(userCert))
+					fmt.Println("certificate:", string(ssh.MarshalAuthorizedKey(userCert)))
+					assert.Equal(t, params.expectFormat, userCert.Signature.Format)
+				})
+			}
 		}
 	}
 }
@@ -339,10 +355,10 @@ func TestSmartCardSessionRecovery(t *testing.T) {
 	srv.pkcs11SessionLost = true
 
 	userCert := testCert()
-	if assert.Error(t, srv.SignCertificate(userCert), "signing should fail") {
+	if assert.Error(t, srv.SignCertificate(userCert, nil), "signing should fail") {
 		// Wait until recovery has kicked in
 		if assert.True(t, wait(srv.Ready)) {
-			assert.NoError(t, srv.SignCertificate(userCert), "signing should now work")
+			assert.NoError(t, srv.SignCertificate(userCert, nil), "signing should now work")
 		}
 	}
 }
@@ -374,7 +390,7 @@ func BenchmarkSmartCard(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				userCert := testCert()
-				assert.NoError(b, smartCardSrv.SignCertificate(userCert), "signing should work")
+				assert.NoError(b, smartCardSrv.SignCertificate(userCert, nil), "signing should work")
 			}
 		})
 	}


### PR DESCRIPTION
The newer defaults for OpenSSH seem to prevent usage of RSA certs with
the default signing algorithm. This patch allows user to request a specific
signing algo.

The server will ask the ssh-agent to sign with a specific algo. This implies
that the server's ssh-agent impl must support the extension flag described
in the draft-miller-ssh-agent-04 Section 4.5.1.