### PR TITLE
feat: handle multiple cert versions

### DIFF
--- a/cliclient/cmd/root.go
+++ b/cliclient/cmd/root.go
@@ -31,7 +31,7 @@ var logLevel = "info"
 func rootInit() {
 	logging.Defaults.DefaultLevel = logLevel
 	if err := logging.Setup(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
@@ -142,13 +142,23 @@ func init() {
 	)
 
 	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_AGENT_CONFIRM")); err == nil && val {
-		ClientConfig.Quiet = true
+		ClientConfig.AgentConfirm = true
 	}
 	RootCmd.PersistentFlags().BoolVar(
 		&ClientConfig.AgentConfirm,
 		"agent-confirm",
 		ClientConfig.AgentConfirm,
 		"Request confirm constraint when storing keys and certs to the agent ($SSH_INSCRIBE_AGENT_CONFIRM)",
+	)
+
+	if val, err := strconv.ParseBool(os.Getenv("SSH_INSCRIBE_AGENT_FILTER")); err == nil && !val {
+		agentFilter = false
+	}
+	RootCmd.PersistentFlags().BoolVar(
+		&agentFilter,
+		"agent-filter",
+		agentFilter,
+		"sshi will setup an internal filtering agent for ssh and exec commands ($SSH_INSCRIBE_AGENT_FILTER)",
 	)
 
 	defLoginAuthEndpoints := []string{}

--- a/pkg/filteringagent/agent.go
+++ b/pkg/filteringagent/agent.go
@@ -1,0 +1,152 @@
+package filteringagent
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+var (
+	ErrNotSupported = errors.New("agent operation not supported")
+	ErrNoSuchKey    = errors.New("agent does not have the specified key")
+)
+
+func New(targetAgent agent.Agent, ca ssh.PublicKey, signatureFormat string, keyType string) agent.Agent {
+	return &filteringAgent{
+		ca:              ca,
+		signatureFormat: signatureFormat,
+		keyType:         keyType,
+		agent:           targetAgent,
+		addedKeys:       make(map[string]bool),
+	}
+}
+
+type filteringAgent struct {
+	ca              ssh.PublicKey
+	signatureFormat string
+	keyType         string
+
+	agent     agent.Agent
+	addedKeys map[string]bool
+}
+
+func (a *filteringAgent) List() ([]*agent.Key, error) {
+	keys, err := a.agent.List()
+	if err != nil {
+		return nil, err
+	}
+	var out []*agent.Key
+	for _, rawKey := range keys {
+		key, err := ssh.ParsePublicKey(rawKey.Marshal())
+		if err != nil {
+			return nil, err
+		}
+		if a.addedKeys[fingerprintSHA256(key)] {
+			out = append(out, rawKey)
+			continue
+		}
+
+		cert, _ := key.(*ssh.Certificate)
+		if cert == nil {
+			continue
+		}
+		if a.ca != nil && !bytes.Equal(cert.SignatureKey.Marshal(), a.ca.Marshal()) {
+			continue
+		}
+		if a.signatureFormat != "" && cert.Signature.Format != a.signatureFormat {
+			continue
+		}
+		if a.keyType != "" && cert.Key.Type() != a.keyType {
+			continue
+		}
+		out = append(out, rawKey)
+	}
+	return out, nil
+}
+
+func (a *filteringAgent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
+	keys, err := a.List()
+	if err != nil {
+		return nil, err
+	}
+	var found bool
+	for _, rawKey := range keys {
+		if bytes.Equal(key.Marshal(), rawKey.Marshal()) {
+			found = true
+		}
+	}
+	if !found {
+		return nil, ErrNoSuchKey
+	}
+	return a.agent.Sign(key, data)
+}
+
+func (a *filteringAgent) Add(key agent.AddedKey) error {
+	signer, err := ssh.NewSignerFromKey(key.PrivateKey)
+	if err != nil {
+		return err
+	}
+	if err := a.agent.Add(key); err != nil {
+		return nil
+	}
+	a.addedKeys[fingerprintSHA256(signer.PublicKey())] = true
+	if key.Certificate != nil {
+		a.addedKeys[fingerprintSHA256(key.Certificate)] = true
+	}
+	return nil
+}
+
+func (a *filteringAgent) Remove(key ssh.PublicKey) error {
+	if !a.addedKeys[fingerprintSHA256(key)] {
+		return ErrNoSuchKey
+	}
+
+	if err := a.agent.Remove(key); err != nil {
+		return err
+	}
+	delete(a.addedKeys, fingerprintSHA256(key))
+	return nil
+}
+
+func (a *filteringAgent) RemoveAll() error {
+	keys, err := a.List()
+	if err != nil {
+		return err
+	}
+	for _, rawKey := range keys {
+		if !a.addedKeys[fingerprintSHA256(rawKey)] {
+			continue
+		}
+		agentKey, err := ssh.ParsePublicKey(rawKey.Marshal())
+		if err != nil {
+			return err
+		}
+		if err := a.agent.Remove(agentKey); err != nil {
+			return err
+		}
+		delete(a.addedKeys, fingerprintSHA256(agentKey))
+	}
+	return nil
+}
+
+func (a *filteringAgent) Lock(_ []byte) error {
+	return ErrNotSupported
+}
+
+func (a *filteringAgent) Unlock(_ []byte) error {
+	return ErrNotSupported
+}
+
+func (a *filteringAgent) Signers() ([]ssh.Signer, error) {
+	return nil, ErrNotSupported
+}
+
+func fingerprintSHA256(key interface{ Marshal() []byte }) string {
+	sha256sum := sha256.Sum256(key.Marshal())
+	hash := base64.RawStdEncoding.EncodeToString(sha256sum[:])
+	return "SHA256:" + hash
+}

--- a/pkg/filteringagent/agent_test.go
+++ b/pkg/filteringagent/agent_test.go
@@ -1,0 +1,351 @@
+package filteringagent
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/aakso/ssh-inscribe/pkg/util"
+)
+
+type certsAndKeys struct {
+	ca1                             *rsa.PrivateKey
+	ca1Cert1Rsa                     *ssh.Certificate
+	ca1Cert1KeyRsa                  *rsa.PrivateKey
+	ca1Cert2Ed25519                 *ssh.Certificate
+	ca1Cert2KeyEd25519              ed25519.PrivateKey
+	ca1Cert3RsaLegacySigningAlgo    *ssh.Certificate
+	ca1Cert3RsaKeyLegacySigningAlgo *rsa.PrivateKey
+	ca2                             ed25519.PrivateKey
+	ca2CertRsa                      *ssh.Certificate
+	ca2CertRsaKey                   *rsa.PrivateKey
+}
+
+func (c *certsAndKeys) addCertsToAgent(t *testing.T, a agent.Agent, skipCa2 bool) {
+	var err error
+	checkErr := func(err error) {
+		if err != nil {
+			assert.FailNow(t, err.Error())
+		}
+	}
+	err = a.Add(agent.AddedKey{PrivateKey: c.ca1Cert1KeyRsa, Certificate: c.ca1Cert1Rsa})
+	checkErr(err)
+	err = a.Add(agent.AddedKey{PrivateKey: c.ca1Cert1KeyRsa})
+	checkErr(err)
+	err = a.Add(agent.AddedKey{PrivateKey: c.ca1Cert2KeyEd25519, Certificate: c.ca1Cert2Ed25519})
+	checkErr(err)
+	err = a.Add(agent.AddedKey{PrivateKey: c.ca1Cert2KeyEd25519})
+	checkErr(err)
+	err = a.Add(agent.AddedKey{PrivateKey: c.ca1Cert3RsaKeyLegacySigningAlgo, Certificate: c.ca1Cert3RsaLegacySigningAlgo})
+	checkErr(err)
+	err = a.Add(agent.AddedKey{PrivateKey: c.ca1Cert3RsaKeyLegacySigningAlgo})
+	checkErr(err)
+	if !skipCa2 {
+		err = a.Add(agent.AddedKey{PrivateKey: c.ca2CertRsaKey, Certificate: c.ca2CertRsa})
+		checkErr(err)
+		err = a.Add(agent.AddedKey{PrivateKey: c.ca2CertRsaKey})
+		checkErr(err)
+	}
+}
+
+func testDeps(t *testing.T) *certsAndKeys {
+	var (
+		r   certsAndKeys
+		err error
+	)
+	checkErr := func(err error) {
+		if err != nil {
+			assert.FailNow(t, err.Error())
+		}
+	}
+	makeCert := func(ca crypto.PrivateKey, certKey crypto.PrivateKey, signingAlgo string) *ssh.Certificate {
+		certKeySigner, err := ssh.NewSignerFromKey(certKey)
+		checkErr(err)
+		cert := &ssh.Certificate{
+			Key:         certKeySigner.PublicKey(),
+			CertType:    ssh.UserCert,
+			KeyId:       "test",
+			ValidAfter:  uint64(time.Now().Unix()),
+			ValidBefore: uint64(time.Now().Add(60 * time.Minute).Unix()),
+		}
+		signer, err := ssh.NewSignerFromKey(ca)
+		checkErr(err)
+		algoSigner := &util.AlgorithmSignerWrapper{
+			Signer:    signer.(ssh.AlgorithmSigner),
+			Algorithm: signingAlgo,
+		}
+		err = cert.SignCert(rand.Reader, algoSigner)
+		checkErr(err)
+		return cert
+	}
+
+	r.ca1, err = rsa.GenerateKey(rand.Reader, 2048)
+	checkErr(err)
+	r.ca1Cert1KeyRsa, err = rsa.GenerateKey(rand.Reader, 2048)
+	checkErr(err)
+	r.ca1Cert1Rsa = makeCert(r.ca1, r.ca1Cert1KeyRsa, ssh.SigAlgoRSASHA2512)
+
+	_, r.ca1Cert2KeyEd25519, err = ed25519.GenerateKey(rand.Reader)
+	checkErr(err)
+	r.ca1Cert2Ed25519 = makeCert(r.ca1, r.ca1Cert2KeyEd25519, ssh.SigAlgoRSASHA2512)
+
+	r.ca1Cert3RsaKeyLegacySigningAlgo, err = rsa.GenerateKey(rand.Reader, 2048)
+	checkErr(err)
+	r.ca1Cert3RsaLegacySigningAlgo = makeCert(r.ca1, r.ca1Cert3RsaKeyLegacySigningAlgo, ssh.SigAlgoRSA)
+
+	_, r.ca2, err = ed25519.GenerateKey(rand.Reader)
+	checkErr(err)
+	r.ca2CertRsaKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	checkErr(err)
+	r.ca2CertRsa = makeCert(r.ca2, r.ca2CertRsaKey, ssh.KeyAlgoED25519)
+
+	return &r
+}
+
+func Test_filteringAgent_Add(t *testing.T) {
+	ta := agent.NewKeyring()
+	deps := testDeps(t)
+	deps.addCertsToAgent(t, ta, true)
+
+	taKeys, err := ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	lenTaKeys := len(taKeys)
+
+	ca1, err := ssh.NewSignerFromKey(deps.ca1)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fa := New(ta, ca1.PublicKey(), "", "")
+	if !assert.NoError(t, fa.Add(agent.AddedKey{PrivateKey: deps.ca2CertRsaKey, Certificate: deps.ca2CertRsa})) {
+		return
+	}
+	if !assert.NoError(t, fa.Add(agent.AddedKey{PrivateKey: deps.ca2CertRsaKey})) {
+		return
+	}
+
+	taKeys, err = ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Len(t, taKeys, lenTaKeys+2)
+
+	agentKeys, err := fa.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	var addedCertFound bool
+	for _, agentKey := range agentKeys {
+		key, err := ssh.ParsePublicKey(agentKey.Blob)
+		if !assert.NoError(t, err) {
+			return
+		}
+		if cert, ok := key.(*ssh.Certificate); ok {
+			if bytes.Equal(cert.Marshal(), deps.ca2CertRsa.Marshal()) {
+				addedCertFound = true
+			}
+		} else {
+			addedKey, err := ssh.NewSignerFromKey(deps.ca2CertRsaKey)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.True(t, bytes.Equal(addedKey.PublicKey().Marshal(), key.Marshal()))
+		}
+	}
+	assert.True(t, addedCertFound)
+
+}
+
+func Test_filteringAgent_List(t *testing.T) {
+	ta := agent.NewKeyring()
+	deps := testDeps(t)
+	deps.addCertsToAgent(t, ta, false)
+
+	t.Run("Ca1_SignAlgo_RSA_SHA2_512", func(t *testing.T) {
+		ca1, err := ssh.NewSignerFromKey(deps.ca1)
+		if !assert.NoError(t, err) {
+			return
+		}
+		fa := New(ta, ca1.PublicKey(), ssh.SigAlgoRSASHA2512, "")
+		agentKeys, err := fa.List()
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, agentKeys, 2)
+		for _, agentKey := range agentKeys {
+			key, err := ssh.ParsePublicKey(agentKey.Blob)
+			if !assert.NoError(t, err) {
+				return
+			}
+			if !assert.IsType(t, &ssh.Certificate{}, key) {
+				return
+			}
+			assert.True(t, bytes.Equal(key.(*ssh.Certificate).SignatureKey.Marshal(), ca1.PublicKey().Marshal()))
+			assert.Contains(t, []string{ssh.KeyAlgoRSA, ssh.KeyAlgoED25519}, key.(*ssh.Certificate).Key.Type())
+		}
+	})
+	t.Run("Ca1_SignAlgo_RSA_SHA2_512_KeyType_ED25519", func(t *testing.T) {
+		ca1, err := ssh.NewSignerFromKey(deps.ca1)
+		if !assert.NoError(t, err) {
+			return
+		}
+		fa := New(ta, ca1.PublicKey(), ssh.SigAlgoRSASHA2512, ssh.KeyAlgoED25519)
+		agentKeys, err := fa.List()
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, agentKeys, 1)
+		for _, agentKey := range agentKeys {
+			key, err := ssh.ParsePublicKey(agentKey.Blob)
+			if !assert.NoError(t, err) {
+				return
+			}
+			if !assert.IsType(t, &ssh.Certificate{}, key) {
+				return
+			}
+			assert.True(t, bytes.Equal(key.(*ssh.Certificate).SignatureKey.Marshal(), ca1.PublicKey().Marshal()))
+			assert.Equal(t, ssh.KeyAlgoED25519, key.(*ssh.Certificate).Key.Type())
+		}
+	})
+	t.Run("Ca2_SignAlgo_ED25519_KeyType_RSA", func(t *testing.T) {
+		ca2, err := ssh.NewSignerFromKey(deps.ca2)
+		if !assert.NoError(t, err) {
+			return
+		}
+		fa := New(ta, ca2.PublicKey(), ssh.KeyAlgoED25519, ssh.KeyAlgoRSA)
+		agentKeys, err := fa.List()
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, agentKeys, 1)
+		for _, agentKey := range agentKeys {
+			key, err := ssh.ParsePublicKey(agentKey.Blob)
+			if !assert.NoError(t, err) {
+				return
+			}
+			if !assert.IsType(t, &ssh.Certificate{}, key) {
+				return
+			}
+			assert.True(t, bytes.Equal(key.(*ssh.Certificate).SignatureKey.Marshal(), ca2.PublicKey().Marshal()))
+			assert.Equal(t, ssh.KeyAlgoRSA, key.(*ssh.Certificate).Key.Type())
+		}
+	})
+
+}
+
+func Test_filteringAgent_Remove(t *testing.T) {
+	ta := agent.NewKeyring()
+	deps := testDeps(t)
+	deps.addCertsToAgent(t, ta, true)
+
+	taKeys, err := ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	lenTaKeys := len(taKeys)
+
+	ca1, err := ssh.NewSignerFromKey(deps.ca1)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fa := New(ta, ca1.PublicKey(), "", "")
+	if !assert.NoError(t, fa.Add(agent.AddedKey{PrivateKey: deps.ca2CertRsaKey})) {
+		return
+	}
+	signer, err := ssh.NewSignerFromKey(deps.ca2CertRsaKey)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.NoError(t, fa.Remove(signer.PublicKey())) {
+		return
+	}
+
+	taKeys, err = ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, taKeys, lenTaKeys)
+}
+
+func Test_filteringAgent_RemoveAll(t *testing.T) {
+	ta := agent.NewKeyring()
+	deps := testDeps(t)
+	deps.addCertsToAgent(t, ta, true)
+
+	taKeys, err := ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	lenTaKeys := len(taKeys)
+
+	ca1, err := ssh.NewSignerFromKey(deps.ca1)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fa := New(ta, ca1.PublicKey(), "", "")
+	faKeys, err := ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	lenFaKeys := len(faKeys)
+
+	if !assert.NoError(t, fa.Add(agent.AddedKey{PrivateKey: deps.ca2CertRsaKey})) {
+		return
+	}
+	if !assert.NoError(t, fa.RemoveAll()) {
+		return
+	}
+
+	taKeys, err = ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Len(t, taKeys, lenTaKeys)
+
+	faKeys, err = ta.List()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Len(t, faKeys, lenFaKeys)
+}
+
+func Test_filteringAgent_Sign(t *testing.T) {
+	ta := agent.NewKeyring()
+	deps := testDeps(t)
+	deps.addCertsToAgent(t, ta, false)
+
+	ca1, err := ssh.NewSignerFromKey(deps.ca1)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	fa := New(ta, ca1.PublicKey(), "", "")
+
+	data := []byte("fake")
+	signature, err := fa.Sign(deps.ca1Cert1Rsa, data)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	signer, err := ssh.NewSignerFromKey(deps.ca1Cert1KeyRsa)
+	assert.NoError(t, signer.PublicKey().Verify(data, signature))
+
+	t.Run("FilteredCert", func(t *testing.T) {
+		data := []byte("fake2")
+		_, err := ta.Sign(deps.ca2CertRsa, data)
+		assert.NoError(t, err)
+
+		_, err = fa.Sign(deps.ca2CertRsa, data)
+		assert.EqualError(t, ErrNoSuchKey, err.Error())
+	})
+}

--- a/pkg/server/signapi/handle_sign.go
+++ b/pkg/server/signapi/handle_sign.go
@@ -81,7 +81,7 @@ func (sa *SignApi) HandleSign(c echo.Context) error {
 
 	var opts crypto.SignerOpts
 	switch c.QueryParam("signing_option") {
-	case "":
+	case "", "ssh-rsa":
 	case "rsa-sha2-256":
 		opts = crypto.SHA256
 	case "rsa-sha2-512":

--- a/pkg/util/sshkey.go
+++ b/pkg/util/sshkey.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"crypto"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func SignatureFormatFromSigningOptionAndCA(opt string, ca ssh.PublicKey) string {
+	switch {
+	case ca != nil && ca.Type() == ssh.KeyAlgoED25519:
+		return ssh.KeyAlgoED25519
+	case ca != nil && ca.Type() == ssh.KeyAlgoRSA && opt == "":
+		return ssh.SigAlgoRSA
+	default:
+		return opt
+	}
+}
+
+type ExtendedAgentSigner interface {
+	ssh.Signer
+	SignWithOpts(rand io.Reader, data []byte, opts crypto.SignerOpts) (*ssh.Signature, error)
+}
+
+type ExtendedAgentSignerWrapper struct {
+	Opts   crypto.SignerOpts
+	Signer ExtendedAgentSigner
+}
+
+func (e *ExtendedAgentSignerWrapper) PublicKey() ssh.PublicKey {
+	return e.Signer.PublicKey()
+}
+
+func (e *ExtendedAgentSignerWrapper) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return e.Signer.SignWithOpts(rand, data, e.Opts)
+}
+
+type AlgorithmSignerWrapper struct {
+	Algorithm string
+	Signer    ssh.AlgorithmSigner
+}
+
+func (a *AlgorithmSignerWrapper) PublicKey() ssh.PublicKey {
+	return a.Signer.PublicKey()
+}
+
+func (a *AlgorithmSignerWrapper) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return a.Signer.SignWithAlgorithm(rand, data, a.Algorithm)
+}


### PR DESCRIPTION
This patch improves the UX when dealing with ssh servers from different
eras. Some might not support ed25519, some might require sha2 signatures.

User can request multiple different certificates by using `--keytype`
and `--signing-option` arguments. To overcome some servers not allowing
more than a few auth attempts, a filtering agent is introduced for `exec`
and `ssh` subcommands.