### PR TITLE
Re-request authenticator credentials on auth failure

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1143,14 +1143,14 @@ func interactiveCredentialsPrompt(name, realm, credentialType, def string) []byt
 	}
 	ret = askPass(prompt)
 
-	// Fall back to terminal input
-	rl, err := readline.New(prompt)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: cannot do readline: %s\n", err)
-		return []byte(def)
-	}
-
 	if ret == nil {
+		// Fall back to terminal input
+		rl, err := readline.New(prompt)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: cannot do readline: %s\n", err)
+			return []byte(def)
+		}
+
 		switch credentialType {
 		case CredentialTypePassword:
 			if ret, err := rl.ReadPassword(prompt); err == nil {


### PR DESCRIPTION
This implements re-request of per-authenticator credentials on auth failures. Avoids having to start from scratch if a late authenticator fails to authenticate -- just that one gets re-prompted with this. Ability to break out of the readline loop with Ctrl+C became important now, so that's implemented as well.

Tested with `sshi req`, appears to work for me.