### PR TITLE
fix: support newer versions of ssh-agent pkcs11 integration

### DIFF
--- a/pkg/keysigner/keysigner_test.go
+++ b/pkg/keysigner/keysigner_test.go
@@ -321,7 +321,7 @@ func TestGetPublicKey(t *testing.T) {
 // This test assumes there is usable key on the smartcard
 func TestAddSmartCard(t *testing.T) {
 	if smartCardId == "" || smartCardPin == "" {
-		t.Skip("No TEST_SMARTCARD_ID or TEST_SMARTCARD_PING set")
+		t.Skip("No TEST_SMARTCARD_ID or TEST_SMARTCARD_PIN set")
 	}
 	srv := New(socketPath, "")
 	defer srv.KillAgent()
@@ -331,15 +331,17 @@ func TestAddSmartCard(t *testing.T) {
 	err := srv.AddSmartcard(smartCardId, smartCardPin)
 	if assert.NoError(t, err) {
 		assert.True(t, wait(srv.Ready))
+		assert.True(t, len(srv.knownSmartCardKeys) > 0)
 	}
 	err = srv.RemoveSmartcard(smartCardId)
 	assert.NoError(t, err)
+	assert.True(t, len(srv.knownSmartCardKeys) == 0)
 }
 
 // This test assumes there is usable key on the smartcard
 func TestSmartCardSessionRecovery(t *testing.T) {
 	if smartCardId == "" || smartCardPin == "" {
-		t.Skip("No TEST_SMARTCARD_ID or TEST_SMARTCARD_PING set")
+		t.Skip("No TEST_SMARTCARD_ID or TEST_SMARTCARD_PIN set")
 	}
 	srv := New(socketPath, "")
 	defer srv.KillAgent()
@@ -349,6 +351,7 @@ func TestSmartCardSessionRecovery(t *testing.T) {
 	err := srv.AddSmartcard(smartCardId, smartCardPin)
 	if assert.NoError(t, err) {
 		assert.True(t, wait(srv.Ready))
+		assert.True(t, len(srv.knownSmartCardKeys) > 0)
 	}
 
 	// Simulate failure


### PR DESCRIPTION
Newer version of OpenSSH expose the PKCS#11 key labels / subjects as
comments. This mean we can no longer rely on the provider path to
recognize smartcard originated keys. Without recognizing those our
smartcard recovery logic is broken. Unfortunately there is no direct way
to do this with the OpenSSH ssh-agent.

With this patch we will track the smartcard keys loaded by us
(fingerprint as key) to know when we need to kick the recovery logic in.

This has been tested with SoftHSM 2.6.1 and OpenSC 0.19 + Nitrokey HSM with OpenSSH 8.9p1.

OpenSSH ssh-agent pkcs11 change related to this:
https://github.com/openssh/openssh-portable/commit/89a8d4525e8edd9958ed3df60cf683551142eae0