### PR TITLE
feat: implement max principals per certificate

### DIFF
--- a/cliclient/cmd/root.go
+++ b/cliclient/cmd/root.go
@@ -273,4 +273,15 @@ func init() {
 	_ = RootCmd.RegisterFlagCompletionFunc("signing-option", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"rsa-sha2-256", "rsa-sha2-512"}, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	if opt := os.Getenv("SSH_INSCRIBE_MAX_PRINCIPALS_PER_CERTIFICATE"); opt != "" {
+		iv, _ := strconv.ParseInt(opt, 10, 64)
+		ClientConfig.MaxPrincipalsPerCertificate = int(iv)
+	}
+	RootCmd.PersistentFlags().IntVar(
+		&ClientConfig.MaxPrincipalsPerCertificate,
+		"max-principals-per-certificate",
+		ClientConfig.MaxPrincipalsPerCertificate,
+		"Optional flag that instructs the server to put maximum of N principals per signed certificate.",
+	)
 }

--- a/pkg/auth/cert.go
+++ b/pkg/auth/cert.go
@@ -8,22 +8,42 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func MakeCertificate(key ssh.PublicKey, actx *AuthContext) *ssh.Certificate {
-	kid := []string{}
-	kid = append(kid, fmt.Sprintf("subject=%q", actx.GetSubjectName()))
+func MakeCertificates(key ssh.PublicKey, actx *AuthContext, validBefore time.Time, maxPrincipalsPerCert int) []*ssh.Certificate {
+	var kid strings.Builder
+	kid.WriteString(fmt.Sprintf("subject=%q", actx.GetSubjectName()))
 	if aid, ok := actx.GetAuthMeta()[MetaAuditID]; ok {
-		kid = append(kid, fmt.Sprintf("audit_id=%q", aid))
+		kid.WriteString(fmt.Sprintf(" audit_id=%q", aid))
 	}
-	kid = append(kid, fmt.Sprintf("via=%q", strings.Join(actx.GetAuthenticators(), ",")))
-	return &ssh.Certificate{
-		Key:             key,
-		CertType:        ssh.UserCert,
-		KeyId:           strings.Join(kid, " "),
-		ValidPrincipals: actx.GetPrincipals(),
-		ValidAfter:      uint64(time.Now().Unix()),
-		Permissions: ssh.Permissions{
-			CriticalOptions: actx.GetCriticalOptions(),
-			Extensions:      actx.GetExtensions(),
-		},
+	kid.WriteString(fmt.Sprintf(" via=%q", strings.Join(actx.GetAuthenticators(), ",")))
+
+	remainingPrincipals := actx.GetPrincipals()
+	if maxPrincipalsPerCert == 0 {
+		maxPrincipalsPerCert = len(remainingPrincipals)
 	}
+	var certs []*ssh.Certificate
+	for {
+		pos := len(remainingPrincipals)
+		if pos > maxPrincipalsPerCert {
+			pos = maxPrincipalsPerCert
+		}
+		principals := remainingPrincipals[:pos]
+		remainingPrincipals = remainingPrincipals[pos:]
+
+		certs = append(certs, &ssh.Certificate{
+			Key:             key,
+			CertType:        ssh.UserCert,
+			KeyId:           kid.String(),
+			ValidPrincipals: principals,
+			ValidAfter:      uint64(time.Now().Unix()),
+			ValidBefore:     uint64(validBefore.Unix()),
+			Permissions: ssh.Permissions{
+				CriticalOptions: actx.GetCriticalOptions(),
+				Extensions:      actx.GetExtensions(),
+			},
+		})
+		if len(remainingPrincipals) == 0 {
+			break
+		}
+	}
+	return certs
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -66,4 +66,8 @@ type Config struct {
 	// SigningOption sets an optional flag to be used in signing. This is only used if the CA's key is RSA.
 	// If not, this option is silently ignored. Valid values: rsa-sha2-256 and rsa-sha2-512
 	SigningOption string
+
+	// MaxPrincipalsPerCertificate is an optional argument that instructs the server to put maximum of N principals
+	// per signed certificate.
+	MaxPrincipalsPerCertificate int
 }


### PR DESCRIPTION
OpenSSH has a limit of 256 principals per certificate.

This patch adds following features:
* server: support max_principals_per_certificate URL parameter to request
          up to n principals where n >= 10.
* client: add max-principals-per-certificate global flag as well as
          SSH_INSCRIBE_MAX_PRINCIPALS_PER_CERTIFICATE envvar.
* client: if --write flag is given and server returns multiple certificates,
          write the certs using {{identify}}-cert{{idx}}.pub format for
          the filename. The index starts from one.
          A user can then use the certificate file directly with:
          `ssh -i /path/to/private_key -o CertificateFile=/path/to/cert`

          At the time of writing, OpenSSH doesn't support multiple certs in
          one file.

Resolves #15