### PR TITLE
feat(server)!: default signing option to `rsa-sha2-256`

### DIFF
--- a/pkg/server/signapi/handle_sign.go
+++ b/pkg/server/signapi/handle_sign.go
@@ -99,9 +99,9 @@ func (sa *SignApi) HandleSign(c echo.Context) error {
 	// Signing option
 	var algo string
 	switch c.QueryParam("signing_option") {
-	case "", "ssh-rsa":
+	case "ssh-rsa":
 		algo = ssh.KeyAlgoRSA
-	case "rsa-sha2-256":
+	case "rsa-sha2-256", "":
 		algo = ssh.KeyAlgoRSASHA256
 	case "rsa-sha2-512":
 		algo = ssh.KeyAlgoRSASHA512


### PR DESCRIPTION
OpenSSH 8.8 released 2021-09-26 disabled `ssh-rsa` signatures, meaning that there's an increasing number of modern systems incompatible with the server's default.

Refs https://www.openssh.com/releasenotes.html#8.8