### PR TITLE
build: switch to goreleaser, build .debs, upload to packagecloud.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,3 +21,12 @@ jobs:
           make dist GORELEASER_ARGS="${{ !startsWith(github.ref, 'refs/tags/') && '--snapshot' || '' }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to Packagecloud
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          gem install --no-document --user-install --bindir ~/.local/bin package_cloud
+          export CLICOLOR_FORCE=1
+          ~/.local/bin/package_cloud push ${{ github.repository }}/any/any dist/*.deb
+          ~/.local/bin/package_cloud push ${{ github.repository }}/rpm_any/rpm_any dist/*.rpm
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+    tags: ["*.*.*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: |
+          make dist GORELEASER_ARGS="${{ !startsWith(github.ref, 'refs/tags/') && '--snapshot' || '' }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *~
 .DS_Store
 build
+dist
 .vscode

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,6 +54,20 @@ nfpms:
         file_info:
           mode: 0775
           group: sshi
+      - src: LICENSE
+        dst: /usr/share/doc/ssh-inscribe/LICENSE
+        packager: deb
+      - src: LICENSE
+        dst: /usr/share/doc/ssh-inscribe/LICENSE
+        type: license
+        packager: rpm
+      - src: README.md
+        dst: /usr/share/doc/ssh-inscribe/README.md
+        packager: deb
+      - src: README.md
+        dst: /usr/share/doc/ssh-inscribe/README.md
+        type: readme
+        packager: rpm
     scripts:
       preinstall: etc/server-pre-install.sh
       postinstall: etc/server-post-install.sh
@@ -70,6 +84,21 @@ nfpms:
     license: *license
     section: *section
     formats: *formats
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/sshi/LICENSE
+        packager: deb
+      - src: LICENSE
+        dst: /usr/share/doc/sshi/LICENSE
+        type: license
+        packager: rpm
+      - src: README.md
+        dst: /usr/share/doc/sshi/README.md
+        packager: deb
+      - src: README.md
+        dst: /usr/share/doc/sshi/README.md
+        type: readme
+        packager: rpm
     rpm:
       group: *rpm_group
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,3 +59,8 @@ nfpms:
     formats: *formats
 checksum:
   name_template: checksums.txt
+changelog:
+  use: github
+  filters:
+    exclude:
+      - ^Merge pull request

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,6 +103,10 @@ nfpms:
       group: *rpm_group
 checksum:
   name_template: checksums.txt
+release:
+  footer: >-
+    apt and dnf/yum package repositories are available at
+    [Packagecloud](https://packagecloud.io/aakso/ssh-inscribe).
 changelog:
   use: github
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,7 +41,7 @@ nfpms:
     homepage: &homepage https://github.com/aakso/ssh-inscribe
     maintainer: &maintainer Anton Aksola <aakso@iki.fi>
     license: &license Apache-2.0
-    formats: &formats [rpm]
+    formats: &formats [deb, rpm]
     contents:
       - src: etc/ssh-inscribe.service
         dst: /usr/lib/systemd/system/ssh-inscribe.service

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,9 @@ nfpms:
     vendor: &vendor Anton Aksola
     homepage: &homepage https://github.com/aakso/ssh-inscribe
     maintainer: &maintainer Anton Aksola <aakso@iki.fi>
+    description: SSH CA server
     license: &license Apache-2.0
+    section: &section net
     formats: &formats [deb, rpm]
     contents:
       - src: etc/ssh-inscribe.service
@@ -55,6 +57,8 @@ nfpms:
     scripts:
       preinstall: etc/server-pre-install.sh
       postinstall: etc/server-post-install.sh
+    rpm:
+      group: &rpm_group Applications/Internet
   - id: sshi
     package_name: sshi
     file_name_template: "{{ .ConventionalFileName }}"
@@ -62,8 +66,12 @@ nfpms:
     vendor: *vendor
     homepage: *homepage
     maintainer: *maintainer
+    description: SSH CA client
     license: *license
+    section: *section
     formats: *formats
+    rpm:
+      group: *rpm_group
 checksum:
   name_template: checksums.txt
 changelog:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,61 @@
+builds:
+  - id: &build_id_ssh_inscribe ssh-inscribe
+    main: .
+    binary: ssh-inscribe
+    ldflags:
+      - -X github.com/aakso/ssh-inscribe/pkg/globals.version={{ .Version }}
+      - -X github.com/aakso/ssh-inscribe/pkg/globals.confDir=/etc/ssh-inscribe
+      - -X github.com/aakso/ssh-inscribe/pkg/globals.varDir=/var/lib/ssh-inscribe
+    goos: [darwin, linux]
+    goarch: [amd64, arm64]
+    ignore:
+      - goos: linux
+        goarch: arm64
+  - id: &build_id_sshi sshi
+    main: ./cliclient/sshi
+    binary: sshi
+    ldflags:
+      - -X github.com/aakso/ssh-inscribe/pkg/globals.version={{ .Version }}
+    goos: [darwin, linux, windows]
+    goarch: [amd64, arm64]
+    ignore:
+      - goos: linux
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
+archives:
+  - format: binary
+    name_template: >-
+      {{ .Binary }}-
+      {{- .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+nfpms:
+  - id: ssh-inscribe
+    package_name: ssh-inscribe
+    file_name_template: "{{ .ConventionalFileName }}"
+    builds: [*build_id_ssh_inscribe]
+    vendor: &vendor Anton Aksola
+    homepage: &homepage https://github.com/aakso/ssh-inscribe
+    maintainer: &maintainer Anton Aksola <aakso@iki.fi>
+    license: &license Apache-2.0
+    formats: &formats [rpm]
+    contents:
+      - src: etc/ssh-inscribe.service
+        dst: /usr/lib/systemd/system/ssh-inscribe.service
+    scripts:
+      preinstall: etc/server-pre-install.sh
+      postinstall: etc/server-post-install.sh
+  - id: sshi
+    package_name: sshi
+    file_name_template: "{{ .ConventionalFileName }}"
+    builds: [*build_id_sshi]
+    vendor: *vendor
+    homepage: *homepage
+    maintainer: *maintainer
+    license: *license
+    formats: *formats
+checksum:
+  name_template: checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,13 @@ nfpms:
     contents:
       - src: etc/ssh-inscribe.service
         dst: /usr/lib/systemd/system/ssh-inscribe.service
+      - dst: /etc/ssh-inscribe
+        type: dir
+      - dst: /var/lib/ssh-inscribe
+        type: dir
+        file_info:
+          mode: 0775
+          group: sshi
     scripts:
       preinstall: etc/server-pre-install.sh
       postinstall: etc/server-post-install.sh

--- a/Makefile
+++ b/Makefile
@@ -1,169 +1,22 @@
-BUILDDIR = build
-DISTDIR = dist
-FAKEROOT_SERVER = $(BUILDDIR)/fakeroot_server
-FAKEROOT_CLIENT = $(BUILDDIR)/fakeroot_client
-PKG_OS = linux
-PKG_ARCH = x86_64
-PKG_NAME_SERVER = ssh-inscribe
-PKG_NAME_CLIENT = sshi
-PKG_MAINTAINER = Anton Aksola <aakso@iki.fi>
-PKG_VERSION = $(shell git describe --tags)
-PKG_SHORT_VERSION = $(shell git describe --tags --abbrev=0)
-PKG_RELEASE = 1
-PKG_VENDOR = Anton Aksola
-PKG_BIN_SSHID = usr/bin/ssh-inscribe
-PKG_BIN_SSHI = usr/bin/sshi
-PKG_ETC = etc/ssh-inscribe
-PKG_SSHID_CONF = $(PKG_ETC)/server_config.yaml
-PKG_SERVICE_SSHID = usr/lib/systemd/system/ssh-inscribe.service
-PKG_USER = sshi
-PKG_GROUP = sshi
-PKG_VARDIR = /var/lib/ssh-inscribe
-PKG_BIN_SUFFIX =
 GO_VERSION = 1.18.9
-GOFLAGS=-mod=vendor
-GOARCH=amd64
+GORELEASER_ARGS = --snapshot
 
-LDFLAGS += -X github.com/aakso/ssh-inscribe/pkg/globals.confDir=/$(PKG_ETC)
-
-PKG_FILES_SERVER = $(PKG_BIN_SSHID) \
-	$(PKG_SERVICE_SSHID)
-
-PKG_FILES_CLIENT = $(PKG_BIN_SSHI)
-HUBARTIFACTS = $(shell find $(BUILDDIR) -d 1 -name "ssh-inscribe*" -o -d 1 -name "sshi*" | xargs -n 1 echo -n " -a ")
-
-BUILDER_IMAGE_NAME ?= sshi_builder_image
-BUILDER_CONTAINER_NAME ?= sshi_builder
-
-define PRE_INSTALL_SERVER
-getent group $(PKG_GROUP) || groupadd -r $(PKG_GROUP)
-getent passwd $(PKG_USER) || useradd -r -g $(PKG_GROUP) -d $(PKG_VARDIR) -s /sbin/nologin $(PKG_USER)
-mkdir -p $(PKG_VARDIR)
-chgrp $(PKG_GROUP) $(PKG_VARDIR)
-chmod g+w $(PKG_VARDIR)
-endef
-export PRE_INSTALL_SERVER
-
-define POST_INSTALL_SERVER
-mkdir -p /$(PKG_ETC)
-test -f /$(PKG_SSHID_CONF) || ssh-inscribe defaults > /$(PKG_SSHID_CONF)
-endef
-export POST_INSTALL_SERVER
-
-build-server: $(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH)
-
-$(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH): LDFLAGS += -X github.com/aakso/ssh-inscribe/pkg/globals.varDir=$(PKG_VARDIR)
-$(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH): LDFLAGS += -X github.com/aakso/ssh-inscribe/pkg/globals.confDir=/$(PKG_ETC)
-$(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH): LDFLAGS += -X github.com/aakso/ssh-inscribe/pkg/globals.version=$(PKG_VERSION)
-$(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH):
-	GOOS=$(PKG_OS) GOFLAGS="$(GOFLAGS)" GOARCH="$(GOARCH)" go build -ldflags '$(LDFLAGS)' \
-		-o $(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH)$(PKG_BIN_SUFFIX) .
-
-build-client: $(BUILDDIR)/sshi-$(PKG_OS)-$(PKG_ARCH)
-
-$(BUILDDIR)/sshi-$(PKG_OS)-$(PKG_ARCH): LDFLAGS += -X github.com/aakso/ssh-inscribe/pkg/globals.version=$(PKG_VERSION)
-$(BUILDDIR)/sshi-$(PKG_OS)-$(PKG_ARCH):
-	GOOS=$(PKG_OS) GOFLAGS="$(GOFLAGS)" GOARCH="$(GOARCH)" go build -ldflags '$(LDFLAGS)' \
-		-o $(BUILDDIR)/sshi-$(PKG_OS)-$(PKG_ARCH)$(PKG_BIN_SUFFIX) ./cliclient/sshi
+.PHONY: all
+all: test dist
 
 .PHONY: dist
 dist:
-	@rm -rf $(DISTDIR)
-	docker build -t $(BUILDER_IMAGE_NAME) -f docker/Dockerfile.builder --build-arg "GO_VERSION=$(GO_VERSION)" .
-	@mkdir -p $(DISTDIR)
-	@docker rm -f $(BUILDER_CONTAINER_NAME) || true
-	docker run -d --rm --name=$(BUILDER_CONTAINER_NAME) $(BUILDER_IMAGE_NAME) /bin/sleep 1800
-	docker exec $(BUILDER_CONTAINER_NAME) make clean-build linux darwin windows rpm \
-		PKG_VERSION="$(PKG_VERSION)" \
-		PKG_SHORT_VERSION="$(PKG_SHORT_VERSION)"
-
-	docker exec $(BUILDER_CONTAINER_NAME) tar -C $(BUILDDIR) -c . | tar -C $(DISTDIR) -x
-
-.PHONY: linux
-linux:
-	$(MAKE) PKG_OS=linux build-server
-	$(MAKE) PKG_OS=linux build-client
-.PHONY: darwin
-darwin:
-	$(MAKE) PKG_OS=darwin build-server
-	$(MAKE) PKG_OS=darwin build-client
-	$(MAKE) PKG_OS=darwin PKG_ARCH=arm64 GOARCH=arm64 build-server
-	$(MAKE) PKG_OS=darwin PKG_ARCH=arm64 GOARCH=arm64 build-client
-.PHONY: windows
-windows:
-	$(MAKE) PKG_OS=windows PKG_BIN_SUFFIX=.exe build-client
-.PHONY: rpm
-rpm:
-	$(MAKE) PKG_OS=linux rpm-client rpm-server
-.PHONY: release
-release: clean test linux darwin rpm windows
-	hub release create -d $(HUBARTIFACTS) -m $(PKG_VERSION) $(PKG_SHORT_VERSION)
-
-.PHONY: rpm-server
-rpm-server: $(BUILDDIR)/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH) rpm_setup_fakeroot rpm_setup_server_fpm_files rpm_create_server_scripts
-	fpm \
-		-n $(PKG_NAME_SERVER) -v "$(PKG_SHORT_VERSION)" \
-		-a "$(PKG_ARCH)" -m "$(PKG_MAINTAINER)" \
-		--vendor "$(PKG_VENDOR)" \
-		--iteration "$(PKG_RELEASE)" \
-		--rpm-os $(PKG_OS) \
-		-s dir -t rpm -f \
-		-C $(FAKEROOT_SERVER) \
-		--pre-install $(BUILDDIR)/server_pre_install.sh \
-		--post-install $(BUILDDIR)/server_post_install.sh \
-		-p $(BUILDDIR) \
-		$(PKG_FILES_SERVER)
-
-.PHONY: rpm-client
-rpm-client: $(BUILDDIR)/sshi-$(PKG_OS)-$(PKG_ARCH) rpm_setup_fakeroot rpm_setup_client_fpm_files
-	fpm \
-		-n $(PKG_NAME_CLIENT) -v "$(PKG_SHORT_VERSION)" \
-		-a "$(PKG_ARCH)" -m "$(PKG_MAINTAINER)" \
-		--vendor "$(PKG_VENDOR)" \
-		--iteration "$(PKG_RELEASE)" \
-		--rpm-os $(PKG_OS) \
-		-s dir -t rpm -f \
-		-C $(FAKEROOT_CLIENT) \
-		-p $(BUILDDIR) \
-		$(PKG_FILES_CLIENT)
-
-.PHONY: rpm_setup_fakeroot
-rpm_setup_fakeroot:
-	mkdir -p $(FAKEROOT_SERVER)/$(PKG_ETC)
-	mkdir -p $(FAKEROOT_SERVER)/usr/bin
-	mkdir -p $(FAKEROOT_SERVER)/usr/lib/systemd/system
-	mkdir -p $(FAKEROOT_CLIENT)/usr/bin
-
-.PHONY: rpm_create_server_scripts
-rpm_create_server_scripts:
-	@echo "$$PRE_INSTALL_SERVER" > $(BUILDDIR)/server_pre_install.sh
-	@echo "$$POST_INSTALL_SERVER" > $(BUILDDIR)/server_post_install.sh
-
-.PHONY: rpm_setup_server_fpm_files
-rpm_setup_server_fpm_files:
-	cp build/ssh-inscribe-$(PKG_OS)-$(PKG_ARCH) $(FAKEROOT_SERVER)/$(PKG_BIN_SSHID)
-	cp etc/ssh-inscribe.service $(FAKEROOT_SERVER)/$(PKG_SERVICE_SSHID)
-
-.PHONY: rpm_setup_client_fpm_files
-rpm_setup_client_fpm_files:
-	cp build/sshi-$(PKG_OS)-$(PKG_ARCH) $(FAKEROOT_CLIENT)/$(PKG_BIN_SSHI)
+	@rm -rf dist
+	docker run --rm \
+		--user "$(shell id -u):$(shell id -g)" \
+		--env GOCACHE=/tmp/go-build \
+		--volume "$$PWD:/work" \
+		--workdir /work \
+		--entrypoint sh \
+		golang:$(GO_VERSION) \
+		-c "curl -fSsL https://goreleaser.com/static/run | bash -s -- release $(GORELEASER_ARGS)"
 
 .PHONY: test
 test:
 	go test $(shell git grep  -l '!race' ./pkg | xargs -n 1 dirname | uniq | sed 's/^/\.\//')
 	go test -race ./pkg/...
-
-
-.PHONY: clean-builder
-clean-builder:
-	docker rm -f $(BUILDER_CONTAINER_NAME) || true
-	docker rmi $(BUILDER_IMAGE_NAME) || true
-
-
-.PHONY: clean-build
-clean-build:
-	rm -rf $(BUILDDIR)
-	rm -rf $(DISTDIR)
-
-.PHONY: clean
-clean: clean-builder clean-build

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ dist:
 	@rm -rf dist
 	docker run --rm \
 		--user "$(shell id -u):$(shell id -g)" \
+		--env CI \
+		--env GITHUB_TOKEN \
 		--env GOCACHE=/tmp/go-build \
 		--volume "$$PWD:/work" \
 		--workdir /work \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Feedback would be appreciated.
 - [ssh-inscribe - SSH CA Client/Server](#ssh-inscribe---ssh-ca-clientserver)
     - [Overview](#overview)
     - [Requirements](#requirements)
-    - [Development version installation](#development-version-installation)
+    - [Installation](#installation)
+      - [Released version](#released-version)
+      - [Development version](#development-version)
     - [Quick start (flat file authentication)](#quick-start-flat-file-authentication)
         - [Install and configure the server](#install-and-configure-the-server)
     - [Configure your hosts to trust the CA public key](#configure-your-hosts-to-trust-the-ca-public-key)
@@ -40,7 +42,16 @@ For client you need:
 - `ssh` binary in path to use the ssh subcommand
 - `ssh-agent` running for convenient use
 
-## Development version installation
+## Installation
+
+### Released version
+Prebuilt binaries and packages are available at
+[project releases](https://github.com/aakso/ssh-inscribe/releases).
+
+apt and dnf/yum package repositories are available at
+[Packagecloud](https://packagecloud.io/aakso/ssh-inscribe).
+
+### Development version
 ```
 go install github.com/aakso/ssh-inscribe/...@latest
 ```

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,6 +1,0 @@
-ARG GO_VERSION
-FROM golang:${GO_VERSION}
-RUN apt update && apt install -y ruby ruby-dev rubygems build-essential rpm && \
-    gem install --no-document fpm
-WORKDIR /work
-COPY . /work

--- a/etc/server-post-install.sh
+++ b/etc/server-post-install.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -eu
 
-mkdir -p /etc/ssh-inscribe
 test -f /etc/ssh-inscribe/server_config.yaml ||
     ssh-inscribe defaults >/etc/ssh-inscribe/server_config.yaml

--- a/etc/server-post-install.sh
+++ b/etc/server-post-install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /etc/ssh-inscribe
+test -f /etc/ssh-inscribe/server_config.yaml ||
+    ssh-inscribe defaults >/etc/ssh-inscribe/server_config.yaml

--- a/etc/server-pre-install.sh
+++ b/etc/server-pre-install.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+getent group sshi || groupadd --system sshi
+getent passwd sshi ||
+    useradd --system \
+            --gid sshi \
+            --home-dir /var/lib/ssh-inscribe \
+            --shell /sbin/nologin \
+            sshi
+mkdir -p /var/lib/ssh-inscribe
+chgrp sshi /var/lib/ssh-inscribe
+chmod g+w /var/lib/ssh-inscribe

--- a/etc/server-pre-install.sh
+++ b/etc/server-pre-install.sh
@@ -8,6 +8,3 @@ getent passwd sshi ||
             --home-dir /var/lib/ssh-inscribe \
             --shell /sbin/nologin \
             sshi
-mkdir -p /var/lib/ssh-inscribe
-chgrp sshi /var/lib/ssh-inscribe
-chmod g+w /var/lib/ssh-inscribe


### PR DESCRIPTION
This does a few things, see individual commits for details. But in a nutshell, switches build to goreleaser, builds .deb packages, uploads debs and rpms to packagecloud.io for repo access, all in CI (but runnable locally, too).

CI builds packages for all master commits as well as PR changes, but only tagged ones are uploaded to packagecloud.

Releases created by goreleaser look like this: https://github.com/scop/ssh-inscribe/releases/tag/0.0.0

The packagecloud repo from my fork produced by this stuff can be browsed at https://packagecloud.io/scop/ssh-inscribe. Repo config instructions are provided there, but they're somewhat messy, here are TL;DR versions:

yum and friends distros:
```shell
cat <<\EOF | sudo tee /etc/yum.repos.d/TEMPORARY-scop-ssh-inscribe.repo >/dev/null
[TEMPORARY-scop-ssh-inscribe]
name=TEMPORARY ssh-inscribe repo
baseurl=https://packagecloud.io/scop/ssh-inscribe/rpm_any/rpm_any/$basearch
gpgcheck=0
repo_gpgcheck=1
gpgkey=https://packagecloud.io/scop/ssh-inscribe/gpgkey
sslverify=1
sslcacert=/etc/pki/tls/certs/ca-bundle.crt
EOF
```

apt distros:
```shell
sudo mkdir -p /etc/apt/keyrings
curl -fSsL https://packagecloud.io/scop/ssh-inscribe/gpgkey | sudo tee /etc/apt/keyrings/TEMPORARY-scop-ssh-inscribe.asc >/dev/null
cat <<\EOF | sudo tee /etc/apt/sources.list.d/TEMPORARY-scop-ssh-inscribe.list >/dev/null
deb [signed-by=/etc/apt/keyrings/TEMPORARY-scop-ssh-inscribe.asc] https://packagecloud.io/scop/ssh-inscribe/any any main
EOF
```

Client packages are tested only to the extent that they install and output help, on Ubuntu 20 and CentOS 7. Server packages are install-tested only on same distros.