### PR TITLE
chore(goreleaser): hush warnings, 2.8+ now required

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - id: &build_id_ssh_inscribe ssh-inscribe
     env:
@@ -30,7 +32,7 @@ builds:
         goarch: arm64
 
 archives:
-  - format: binary
+  - formats: binary
     name_template: >-
       {{ .Binary }}-
       {{- .Os }}-
@@ -43,7 +45,7 @@ nfpms:
   - id: ssh-inscribe
     package_name: ssh-inscribe
     file_name_template: "{{ .ConventionalFileName }}"
-    builds: [*build_id_ssh_inscribe]
+    ids: [*build_id_ssh_inscribe]
     vendor: &vendor Anton Aksola
     homepage: &homepage https://github.com/aakso/ssh-inscribe
     maintainer: &maintainer Anton Aksola <aakso@iki.fi>
@@ -100,7 +102,7 @@ nfpms:
   - id: sshi
     package_name: sshi
     file_name_template: "{{ .ConventionalFileName }}"
-    builds: [*build_id_sshi]
+    ids: [*build_id_sshi]
     vendor: *vendor
     homepage: *homepage
     maintainer: *maintainer


### PR DESCRIPTION
goreleaser 2.8.2 warns:

> only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration

> DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info

> DEPRECATED:  nfpms.builds  should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info

