### PR TITLE
chore(ci): generate GitHub artifact attestations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,9 @@ on:
     tags: ["*.*.*"]
 
 permissions:
+  attestations: write
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -21,6 +23,11 @@ jobs:
           make dist GORELEASER_ARGS="${{ !startsWith(github.ref, 'refs/tags/') && '--snapshot' || '' }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate artifact attestations
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest@v4
+        with:
+          subject-checksums: dist/checksums.txt
       - name: Upload to Packagecloud
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,6 +141,9 @@ checksum:
 
 release:
   footer: >-
+    Downloads can be [verified](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-an-artifact-attestation-for-binaries)
+    against GitHub artifact attestations.
+
     apt and dnf/yum package repositories are available at
     [Packagecloud](https://packagecloud.io/aakso/ssh-inscribe).
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ For client you need:
 Prebuilt binaries and packages are available at
 [project releases](https://github.com/aakso/ssh-inscribe/releases).
 
+Downloads can be [verified](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-an-artifact-attestation-for-binaries)
+against GitHub artifact attestations.
+
 apt and dnf/yum package repositories are available at
 [Packagecloud](https://packagecloud.io/aakso/ssh-inscribe).
 


### PR DESCRIPTION
Info about artifact attestations: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations

Sample results in my fork: https://github.com/scop/ssh-inscribe/attestations